### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2](https://github.com/knutwalker/fuzzy-select/compare/0.1.1...0.1.2) - 2024-06-12
+
+### Changes
+
+- Upgrade dependencies ([#6](https://github.com/knutwalker/fuzzy-select/pull/6))
+- Make selected text contrast with background ([#5](https://github.com/knutwalker/fuzzy-select/pull/5))
+- Fix doctest
+
 ## [0.1.1](https://github.com/knutwalker/fuzzy-select/compare/v0.1.0...v0.1.1) - 2024-01-15
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzzy-select"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/knutwalker/fuzzy-select"
 authors = ["Paul Horn <developer@knutwalker.de>"]


### PR DESCRIPTION
## 🤖 New release
* `fuzzy-select`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/knutwalker/fuzzy-select/compare/0.1.1...0.1.2) - 2024-06-12

### Changes

- Upgrade dependencies ([#6](https://github.com/knutwalker/fuzzy-select/pull/6))
- Make selected text contrast with background ([#5](https://github.com/knutwalker/fuzzy-select/pull/5))
- Fix doctest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).