### PR TITLE
Fix prompt immediately selecting after opened on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -754,8 +754,7 @@ impl Prompt {
                 self.height = u32::from(h.saturating_sub(1));
                 return Changed::Selection;
             }
-            Event::Mouse(_) | Event::Paste(_) => {}
-            _ => {}
+            Event::Mouse(_) | Event::Paste(_) | Event::Key(_) => {}
         };
 
         Changed::Nothing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use std::{
 
 use crossterm::{
     cursor,
-    event::{Event, KeyCode, KeyModifiers},
+    event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     style,
     terminal::{self, ClearType},
     QueueableCommand,
@@ -742,7 +742,7 @@ impl Prompt {
 
     fn handle_event(&mut self, event: &Event) -> Changed {
         match event {
-            Event::Key(key) => return self.handle_key_event(key.code, key.modifiers),
+            Event::Key(KeyEvent {code, modifiers, kind: KeyEventKind::Press, ..}) => return self.handle_key_event(*code, *modifiers),
             Event::FocusLost => self.active = false,
             Event::FocusGained => self.active = true,
             Event::Resize(_, h) => {
@@ -750,6 +750,7 @@ impl Prompt {
                 return Changed::Selection;
             }
             Event::Mouse(_) | Event::Paste(_) => {}
+            _ => {}
         };
 
         Changed::Nothing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,12 @@ impl Prompt {
 
     fn handle_event(&mut self, event: &Event) -> Changed {
         match event {
-            Event::Key(KeyEvent {code, modifiers, kind: KeyEventKind::Press, ..}) => return self.handle_key_event(*code, *modifiers),
+            Event::Key(KeyEvent {
+                code,
+                modifiers,
+                kind: KeyEventKind::Press,
+                ..
+            }) => return self.handle_key_event(*code, *modifiers),
             Event::FocusLost => self.active = false,
             Event::FocusGained => self.active = true,
             Event::Resize(_, h) => {


### PR DESCRIPTION
When running the example on Windows, the prompt is immediately selected, giving me no opportunity to select an option.

```
PS D:\git\fuzzy-select> cargo run --example demo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target\debug\examples\demo.exe`
You have chosen: "General Kenobi"
PS D:\git\fuzzy-select>
```

On Windows, `KeyEvent`s have an associated `KeyEventKind`; it seems like fuzzy-select should only handle Press events. Related: https://github.com/veeso/tui-realm/issues/54
Making this change fixes the prompt on Windows.

I also tested this change on (Debian) WSL and it seems fine there.