### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3](https://github.com/knutwalker/fuzzy-select/compare/0.1.2...0.1.3) - 2024-07-08
+
+### Changes
+
+- Fix prompt immediately selecting after opened on Windows ([#7](https://github.com/knutwalker/fuzzy-select/pull/7))
+
 ## [0.1.2](https://github.com/knutwalker/fuzzy-select/compare/0.1.1...0.1.2) - 2024-06-12
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzzy-select"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 repository = "https://github.com/knutwalker/fuzzy-select"
 authors = ["Paul Horn <developer@knutwalker.de>"]


### PR DESCRIPTION
## 🤖 New release
* `fuzzy-select`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/knutwalker/fuzzy-select/compare/0.1.2...0.1.3) - 2024-07-08

### Changes

- Fix prompt immediately selecting after opened on Windows ([#7](https://github.com/knutwalker/fuzzy-select/pull/7))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).